### PR TITLE
feat: separate image attachments from user text

### DIFF
--- a/components/layout/CustomComposer.tsx
+++ b/components/layout/CustomComposer.tsx
@@ -15,7 +15,10 @@ export function CustomComposer() {
 
       {/* leading: 附件按钮 */}
       <div className="[grid-area:leading] relative">
-        <UIComposer.AddAttachment className="rounded-full w-8 h-8 text-foreground/80 hover:text-foreground">
+        <UIComposer.AddAttachment
+          accept="image/*"
+          className="rounded-full w-8 h-8 text-foreground/80 hover:text-foreground"
+        >
           <Plus className="h-4 w-4" />
         </UIComposer.AddAttachment>
       </div>


### PR DESCRIPTION
## Summary
- display image attachments above user message text
- allow selecting image files in custom composer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*
- `npm run build` *(fails: Failed to fetch Montserrat from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d16c0ec8320a0fee187547a650a